### PR TITLE
Improve export logic and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,10 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyinstaller
+          pip install --no-cache-dir -r requirements.txt
+          pip install --no-cache-dir pyinstaller
+      - name: Lint
+        run: python -m py_compile bookforge_core.py cli_app.py gui_app.py gui_app_main.py build_app.py client_config.py
 
       - name: Build Windows EXE
         run: |
@@ -50,8 +52,10 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           python3 -m pip install --upgrade pip
-          pip3 install -r requirements.txt
-          pip3 install pyinstaller
+          pip3 install --no-cache-dir -r requirements.txt
+          pip3 install --no-cache-dir pyinstaller
+      - name: Lint
+        run: python3 -m py_compile bookforge_core.py cli_app.py gui_app.py gui_app_main.py build_app.py client_config.py
 
       - name: Build macOS App
         run: |

--- a/README.md
+++ b/README.md
@@ -5,25 +5,25 @@
 ![License: MIT](https://img.shields.io/badge/License-MIT-green)
 ![Status](https://img.shields.io/badge/Status-Active-brightgreen)
 
-**AI-powered book writer using Google Gemini API + Audiobook generator (ElevenLabs) with GUI, CLI, and Docker support.**
+**AI-powered book writer using Google Gemini API and ElevenLabs for audiobook generation. Includes GUI, CLI and Docker support.**
 
 ---
 
 ## 🚀 Features
-✅ Generate full-length books using AI (Google Gemini)  
-✅ Automatic research and chapter writing  
-✅ Export to **PDF**, **EPUB**, and **Markdown**  
-✅ Generate **Audiobooks** with ElevenLabs  
-✅ GUI built with **Streamlit**  
-✅ CLI mode for automation  
-✅ Build as standalone **EXE / macOS App**  
-✅ Docker support  
+- Generate full-length books using Google Gemini
+- Automatic research and chapter writing
+- Export to **PDF**, **EPUB**, and **Markdown**
+- Optional audiobook generation with ElevenLabs
+- GUI built with **Streamlit**
+- CLI mode for automation
+- Build as standalone **EXE / macOS App**
+- Docker support
 
 ---
 
 ## 🖼 Preview
-![BookForge Pro GUI](docs/screenshot.png)  
-*(Replace this with actual screenshot from your GUI later)*
+![BookForge Pro GUI](docs/screenshot.png)
+*(Replace this with an actual screenshot from your GUI later)*
 
 ---
 
@@ -33,3 +33,34 @@
 ```bash
 git clone https://github.com/Fr0stByt3s-21/bookforge-pro.git
 cd bookforge-pro
+```
+
+### 2. Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Configure API Keys
+```bash
+export GEMINI_API_KEY=your_gemini_key
+export ELEVENLABS_API_KEY=your_elevenlabs_key
+```
+
+### 4. Run GUI
+```bash
+python gui_app.py
+```
+
+### 5. Run CLI
+```bash
+python cli_app.py --topic "My Book" --words 30000 --export pdf,epub --audiobook yes
+```
+
+### 6. Docker
+```bash
+docker build -t bookforge-pro .
+docker run -p 8501:8501 bookforge-pro
+```
+
+### 7. GitHub Actions Build
+Tag a commit with `vX.Y.Z` to trigger the cross-platform build workflow.

--- a/bookforge_core.py
+++ b/bookforge_core.py
@@ -60,11 +60,21 @@ def write_chapter(title, research_notes):
     return path
 
 def compile_book():
-    subprocess.run("cat chapters/*.md > final_book.md", shell=True)
+    """Combine chapter files into a single Markdown book."""
+    with open("final_book.md", "w", encoding="utf-8") as outfile:
+        for filename in sorted(os.listdir("chapters")):
+            if filename.endswith(".md"):
+                with open(os.path.join("chapters", filename), "r", encoding="utf-8") as infile:
+                    outfile.write(infile.read())
+                    outfile.write("\n\n")
 
-def export_formats():
-    subprocess.run("pandoc final_book.md -o final_book.pdf", shell=True)
-    subprocess.run("pandoc final_book.md -o final_book.epub", shell=True)
+def export_formats(formats):
+    """Export the compiled book to the requested formats."""
+    if "pdf" in formats:
+        subprocess.run("pandoc final_book.md -o final_book.pdf", shell=True)
+    if "epub" in formats:
+        subprocess.run("pandoc final_book.md -o final_book.epub", shell=True)
+    # Markdown export is simply the existing file
 
 def generate_audiobook():
     with open("final_book.md", "r") as f:
@@ -84,7 +94,7 @@ def run_pipeline(topic, words, audiobook, export_formats_list):
         research = research_chapter(title)
         write_chapter(title, research)
     compile_book()
-    export_formats()
+    export_formats(export_formats_list)
     if audiobook == "yes":
         generate_audiobook()
     print("✅ BookForge Pro: All steps completed!")


### PR DESCRIPTION
## Summary
- add logic to export only requested formats
- build final book in Python for cross-platform support
- expand README with complete setup instructions
- add lint step to GitHub Actions build workflow

## Testing
- `python -m py_compile *.py`
- `python cli_app.py -h` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687ae823fdc0832e94f107cc4cf1d00f